### PR TITLE
Fix CVE-2026-22778

### DIFF
--- a/Dockerfile.hpu.ubi
+++ b/Dockerfile.hpu.ubi
@@ -69,8 +69,8 @@ RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 2 && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 # Install base Python packages
-RUN pip install setuptools==79.0.1 wheel setuptools_scm && \
-    pip install --upgrade Jinja2 protobuf urllib3 requests
+RUN pip install --no-cache-dir setuptools==79.0.1 wheel setuptools_scm && \
+    pip install --no-cache-dir --upgrade Jinja2 protobuf urllib3 requests
 
 # Setup Habana repository and install Habana packages
 RUN printf "[habanalabs]\\nname=Habana RH9 Linux repo\\nbaseurl=https://${ARTIFACTORY_URL}/artifactory/rhel/9/9.6\\ngpgkey=https://${ARTIFACTORY_URL}/artifactory/rhel/9/9.6/repodata/repomd.xml.key\\ngpgcheck=1\\n" > /etc/yum.repos.d/habanalabs.repo && \
@@ -96,7 +96,7 @@ RUN printf "[habanalabs]\\nname=Habana RH9 Linux repo\\nbaseurl=https://${ARTIFA
           /etc/yum.repos.d/CentOS-Linux-AppStream.repo
 
 # Install Habana media loader and configure Python path
-RUN pip install habana-media-loader=="${SYNAPSE_VERSION}"."${SYNAPSE_REVISION}" && \
+RUN pip install --no-cache-dir habana-media-loader=="${SYNAPSE_VERSION}"."${SYNAPSE_REVISION}" && \
     echo "/usr/lib/habanalabs" > $(python3 -c "import sysconfig; print(sysconfig.get_path('platlib'))")/habanalabs-graph.pth
 
 # ============================================================================
@@ -122,6 +122,7 @@ RUN PT_PACKAGE_NAME="pytorch_modules-v${PT_VERSION}_${SYNAPSE_VERSION}_${SYNAPSE
     tar -zxf "${PT_PACKAGE_NAME}" -C "${TMP_PATH}" && \
     cd "${TMP_PATH}" && \
     export SKIP_INSTALL_DEPENDENCIES=1 && \
+    export PIP_NO_CACHE_DIR=1 && \
     ./install.sh $SYNAPSE_VERSION $SYNAPSE_REVISION $TORCH_TYPE && \
     cd / && \
     rm -rf "${TMP_PATH}" "${PT_PACKAGE_NAME}"
@@ -169,11 +170,11 @@ RUN set -e && \
     git remote add upstream https://github.com/vllm-project/vllm.git && \
     git fetch upstream --tags && \
     git checkout ${VLLM_PROJECT_COMMIT} && \
-    pip install -r <(sed '/^torch/d' requirements/build.txt) && \
-    VLLM_TARGET_DEVICE=empty pip install --no-build-isolation . && \
+    pip install --no-cache-dir -r <(sed '/^torch/d' requirements/build.txt) && \
+    VLLM_TARGET_DEVICE=empty pip install --no-cache-dir --no-build-isolation . && \
     cd $VLLM_PATH2 && \
     git checkout ${VLLM_GAUDI_COMMIT} && \
-    VLLM_TARGET_DEVICE=hpu pip install -v . --no-build-isolation
+    VLLM_TARGET_DEVICE=hpu pip install --no-cache-dir -v . --no-build-isolation
 
 # The scripts below are used for benchmarks testing and autocalc:
 # RUN pip3 install -v -e $VLLM_PATH/tests/vllm_test_utils

--- a/Dockerfile.konflux.gaudi
+++ b/Dockerfile.konflux.gaudi
@@ -69,8 +69,8 @@ RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 2 && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 # Install base Python packages
-RUN pip install setuptools==79.0.1 wheel setuptools_scm && \
-    pip install --upgrade Jinja2 protobuf urllib3 requests
+RUN pip install --no-cache-dir setuptools==79.0.1 wheel setuptools_scm && \
+    pip install --no-cache-dir --upgrade Jinja2 protobuf urllib3 requests
 
 # Setup Habana repository and install Habana packages
 RUN printf "[habanalabs]\\nname=Habana RH9 Linux repo\\nbaseurl=https://${ARTIFACTORY_URL}/artifactory/rhel/9/9.6\\ngpgkey=https://${ARTIFACTORY_URL}/artifactory/rhel/9/9.6/repodata/repomd.xml.key\\ngpgcheck=1\\n" > /etc/yum.repos.d/habanalabs.repo && \
@@ -96,7 +96,7 @@ RUN printf "[habanalabs]\\nname=Habana RH9 Linux repo\\nbaseurl=https://${ARTIFA
           /etc/yum.repos.d/CentOS-Linux-AppStream.repo
 
 # Install Habana media loader and configure Python path
-RUN pip install habana-media-loader=="${SYNAPSE_VERSION}"."${SYNAPSE_REVISION}" && \
+RUN pip install --no-cache-dir habana-media-loader=="${SYNAPSE_VERSION}"."${SYNAPSE_REVISION}" && \
     echo "/usr/lib/habanalabs" > $(python3 -c "import sysconfig; print(sysconfig.get_path('platlib'))")/habanalabs-graph.pth
 
 # ============================================================================
@@ -122,6 +122,7 @@ RUN PT_PACKAGE_NAME="pytorch_modules-v${PT_VERSION}_${SYNAPSE_VERSION}_${SYNAPSE
     tar -zxf "${PT_PACKAGE_NAME}" -C "${TMP_PATH}" && \
     cd "${TMP_PATH}" && \
     export SKIP_INSTALL_DEPENDENCIES=1 && \
+    export PIP_NO_CACHE_DIR=1 && \
     ./install.sh $SYNAPSE_VERSION $SYNAPSE_REVISION $TORCH_TYPE && \
     cd / && \
     rm -rf "${TMP_PATH}" "${PT_PACKAGE_NAME}"
@@ -169,11 +170,11 @@ RUN set -e && \
     git remote add upstream https://github.com/vllm-project/vllm.git && \
     git fetch upstream --tags && \
     git checkout ${VLLM_PROJECT_COMMIT} && \
-    pip install -r <(sed '/^torch/d' requirements/build.txt) && \
-    VLLM_TARGET_DEVICE=empty pip install --no-build-isolation . && \
+    pip install --no-cache-dir -r <(sed '/^torch/d' requirements/build.txt) && \
+    VLLM_TARGET_DEVICE=empty pip install --no-cache-dir --no-build-isolation . && \
     cd $VLLM_PATH2 && \
     git checkout ${VLLM_GAUDI_COMMIT} && \
-    VLLM_TARGET_DEVICE=hpu pip install -v . --no-build-isolation
+    VLLM_TARGET_DEVICE=hpu pip install --no-cache-dir -v . --no-build-isolation
 
 # The scripts below are used for benchmarks testing and autocalc:
 # RUN pip3 install -v -e $VLLM_PATH/tests/vllm_test_utils

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -32,7 +32,7 @@ msgspec
 gguf >= 0.13.0
 importlib_metadata; python_version < '3.10'
 mistral_common[opencv] >= 1.5.4
-opencv-python-headless >= 4.11.0    # required for video IO
+opencv-python-headless >= 4.13.0    # required for video IO
 pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
 setuptools>=77.0.3,<80; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -30,7 +30,7 @@ mamba_ssm # required for plamo2 test
 matplotlib # required for qwen-vl test
 mistral_common[opencv] >= 1.5.4 # required for pixtral test
 num2words # required for smolvlm test
-opencv-python-headless >= 4.11.0 # required for video test
+opencv-python-headless >= 4.13.0 # required for video test
 datamodel_code_generator # required for minicpm3 test
 lm-eval[api]==0.4.8 # required for model evaluation test
 mteb>=1.38.11, <2 # required for mteb test

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -421,7 +421,7 @@ opencensus==0.11.4
     # via ray
 opencensus-context==0.1.3
     # via opencensus
-opencv-python-headless==4.11.0.86
+opencv-python-headless==4.13.0.90
     # via
     #   -r requirements/test.in
     #   mistral-common


### PR DESCRIPTION
This fixes CVE-2026-22778 by bumping to a new release of opencv-python-headless to 4.13.0. There is also a fix to prevent pip from creating a cache.